### PR TITLE
Reduce API image size, create a `-debug` image

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Extract SHA tag
       id: sha-tag
       run: |
-        SHA_TAG=$(echo '${{ needs.build-debug.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
+        SHA_TAG=$(echo '${{ needs.build-debug.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}-debug$' | head -n1)
         echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
 
     - name: Run Trivy vulnerability scanner on debug image

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -21,7 +21,7 @@ on:
     types: [ created ]
 
 jobs:
-  build:
+  build-slim:
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -51,18 +51,59 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push
+    - name: Build and push slim image
       uses: docker/build-push-action@v6
       with:
         context: .
         file: ./api/Dockerfile
+        target: slim
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+  build-debug:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    outputs:
+      image-tags: ${{ steps.meta.outputs.tags }}
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Docker meta for debug
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/api
+        tags: |
+          type=semver,pattern={{version}}-debug
+          type=semver,pattern={{major}}.{{minor}}-debug
+          type=semver,pattern={{major}}-debug
+          type=ref,event=branch,suffix=-debug
+          type=ref,event=pr,suffix=-debug
+          type=sha,suffix=-debug
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push debug image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./api/Dockerfile
+        target: debug
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-slim
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     concurrency:
       group: deploy-${{ github.workflow }}-${{ github.ref }}
@@ -75,7 +116,7 @@ jobs:
     - name: Extract SHA tag
       id: sha-tag
       run: |
-        SHA_TAG=$(echo '${{ needs.build.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
+        SHA_TAG=$(echo '${{ needs.build-slim.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
         echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
 
     - name: Login to Azure
@@ -94,7 +135,7 @@ jobs:
 
   trivy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-slim
     permissions:
       contents: read
       security-events: write
@@ -103,7 +144,7 @@ jobs:
     - name: Extract SHA tag
       id: sha-tag
       run: |
-        SHA_TAG=$(echo '${{ needs.build.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
+        SHA_TAG=$(echo '${{ needs.build-slim.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
         echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
 
     - name: Run Trivy vulnerability scanner

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -101,9 +101,65 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
-  deploy:
+  trivy-slim:
     runs-on: ubuntu-latest
     needs: build-slim
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Extract SHA tag
+      id: sha-tag
+      run: |
+        SHA_TAG=$(echo '${{ needs.build-slim.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
+        echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+    - name: Run Trivy vulnerability scanner on slim image
+      uses: aquasecurity/trivy-action@0.33.1
+      with:
+        image-ref: ${{ steps.sha-tag.outputs.tag }}
+        format: 'sarif'
+        output: 'trivy-slim-results.sarif'
+
+    - name: Upload Trivy scan results for slim image to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-slim-results.sarif'
+        category: 'slim-image'
+
+  trivy-debug:
+    runs-on: ubuntu-latest
+    needs: build-debug
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Extract SHA tag
+      id: sha-tag
+      run: |
+        SHA_TAG=$(echo '${{ needs.build-debug.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
+        echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+    - name: Run Trivy vulnerability scanner on debug image
+      uses: aquasecurity/trivy-action@0.33.1
+      with:
+        image-ref: ${{ steps.sha-tag.outputs.tag }}
+        format: 'sarif'
+        output: 'trivy-debug-results.sarif'
+
+    - name: Upload Trivy scan results for debug image to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-debug-results.sarif'
+        category: 'debug-image'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ build-slim, trivy-slim, trivy-debug ]
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     concurrency:
       group: deploy-${{ github.workflow }}-${{ github.ref }}
@@ -132,30 +188,3 @@ jobs:
         imageToDeploy: ${{ steps.sha-tag.outputs.tag }}
         containerAppName: ca-dlqt-api
         resourceGroup: rg-dlqt
-
-  trivy:
-    runs-on: ubuntu-latest
-    needs: build-slim
-    permissions:
-      contents: read
-      security-events: write
-
-    steps:
-    - name: Extract SHA tag
-      id: sha-tag
-      run: |
-        SHA_TAG=$(echo '${{ needs.build-slim.outputs.image-tags }}' | grep -E ':sha-[a-f0-9]{7}$' | head -n1)
-        echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.33.1
-      with:
-        image-ref: ${{ steps.sha-tag.outputs.tag }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,15 +1,31 @@
-# Build
+# Build stage
 FROM golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o api ./api
 
-# Runtime
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+# Build optimized binary for slim image
+RUN CGO_ENABLED=0 GOOS=linux go build \
+  -ldflags="-s -w" \
+  -trimpath \
+  -o api-slim ./api
+
+# Build debug binary (no optimization flags)
+RUN CGO_ENABLED=0 GOOS=linux go build \
+  -o api-debug ./api
+
+# Slim image (distroless with optimized binary)
+FROM gcr.io/distroless/static-debian12:nonroot AS slim
+COPY --from=builder /app/api-slim /api
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/api"]
+
+# Debug image (alpine with unoptimized binary)
+FROM alpine:latest AS debug
+RUN apk --no-cache add ca-certificates curl
 WORKDIR /root/
-COPY --from=builder /app/api .
+COPY --from=builder /app/api-debug ./api
 EXPOSE 8080
 CMD ["./api"]


### PR DESCRIPTION
For main/slim API image:
- added `go build` optimization flags, reducing binary size
- uses `distroless` for base image, reducing total image size

Results: reduced 35.25MB to 19.44 MB
<img width="761" height="113" alt="image" src="https://github.com/user-attachments/assets/f9712c12-803a-4c9f-9258-373375060f1e" />

For debug API image:
- didn't add any `go build` optimization flags
- uses Alpine for base image
- added `curl` package for easier API debugging